### PR TITLE
Allow overwriting API URL via data-client-api-url

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -22,6 +22,7 @@ window.FP_EMBED_SANDBOX = () => {
     const fileUrl = $box.getAttribute('data-file-url')
     const metadata = $box.getAttribute('data-metadata')
     const clientKey = $box.getAttribute('data-client-key')
+    const clientApiUrl = $box.getAttribute('data-client-api-url')
     const filePickerKey = $box.getAttribute('data-filepicker-key')
 
     const serverKey = (
@@ -42,6 +43,7 @@ window.FP_EMBED_SANDBOX = () => {
       sandboxId,
       clientKey,
       serverKey,
+      clientApiUrl,
       serverSecretKey,
       filePickerKey,
 

--- a/app/views/Sandbox.js
+++ b/app/views/Sandbox.js
@@ -49,7 +49,11 @@ export default class Sandbox extends Component {
       throw new Error('No FilePreviews Client Key provided.')
     }
 
-    this.preview = new FilePreviews({ apiKey: props.clientKey })
+    this.preview = new FilePreviews({
+      apiKey: props.clientKey,
+      apiUrl: props.clientApiUrl
+    })
+
     this.FilePreviewsInterval = null
   }
 


### PR DESCRIPTION
Once https://github.com/GetBlimp/filepreviews.js/pull/8 is available this'll come in handy